### PR TITLE
Improvement: welcome component

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -3,6 +3,7 @@
     <head>
         <meta charset="UTF-8" />
         <title>{% block title %}Welcome!{% endblock %}</title>
+        <link rel="stylesheet" href="{{ asset('assets/base.css') }}">
         {% block stylesheets %}{% endblock %}
         <link rel="icon" type="image/x-icon" href="{{ asset('favicon.ico') }}" />
     </head>

--- a/app/Resources/views/components/welcome/style_guide.html.twig
+++ b/app/Resources/views/components/welcome/style_guide.html.twig
@@ -1,0 +1,15 @@
+{% import 'components/welcome/welcome.html.twig' as welcome %}
+
+<h2>Welcome</h2>
+
+<p>A simple example component.</p>
+
+<p>Code:</p>
+<code>
+    {% verbatim %}
+    {{ welcome.render('the style guide') }}
+    {% endverbatim %}
+</code>
+
+<p>Example:</p>
+{{ welcome.render('the style guide') }}

--- a/app/Resources/views/components/welcome/welcome.html.twig
+++ b/app/Resources/views/components/welcome/welcome.html.twig
@@ -1,5 +1,5 @@
 {% macro render(name) %}
     <div class="welcome">
-        <h1><span class="welcome--lead">Welcome to</span> {{ name }}</h1>
+        <h1><span class="welcome__lead">Welcome to</span> {{ name }}</h1>
     </div>
 {% endmacro %}

--- a/app/Resources/views/components/welcome/welcome.html.twig
+++ b/app/Resources/views/components/welcome/welcome.html.twig
@@ -1,0 +1,5 @@
+{% macro render(name) %}
+    <div class="welcome">
+        <h1><span class="welcome--lead">Welcome to</span> {{ name }}</h1>
+    </div>
+{% endmacro %}

--- a/app/Resources/views/default/index.html.twig
+++ b/app/Resources/views/default/index.html.twig
@@ -1,12 +1,11 @@
 {% extends 'base.html.twig' %}
 
+{% import 'components/welcome/welcome.html.twig' as welcome %}
+
 {% block body %}
     <div id="wrapper">
         <div id="container">
-            <div id="welcome">
-                <h1><span>Welcome to</span> Symfony {{ constant('Symfony\\Component\\HttpKernel\\Kernel::VERSION') }}</h1>
-            </div>
-
+            {{ welcome.render('Symfony ' ~ constant('Symfony\\Component\\HttpKernel\\Kernel::VERSION')) }}
             <div id="status">
                 <p>
                     <svg id="icon-status" width="1792" height="1792" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg"><path d="M1671 566q0 40-28 68l-724 724-136 136q-28 28-68 28t-68-28l-136-136-362-362q-28-28-28-68t28-68l136-136q28-28 68-28t68 28l294 295 656-657q28-28 68-28t68 28l136 136q28 28 28 68z" fill="#759E1A"/></svg>
@@ -47,30 +46,5 @@
 {% endblock %}
 
 {% block stylesheets %}
-<style>
-    body { background: #F5F5F5; font: 18px/1.5 sans-serif; }
-    h1, h2 { line-height: 1.2; margin: 0 0 .5em; }
-    h1 { font-size: 36px; }
-    h2 { font-size: 21px; margin-bottom: 1em; }
-    p { margin: 0 0 1em 0; }
-    a { color: #0000F0; }
-    a:hover { text-decoration: none; }
-    code { background: #F5F5F5; max-width: 100px; padding: 2px 6px; word-wrap: break-word; }
-    #wrapper { background: #FFF; margin: 1em auto; max-width: 800px; width: 95%; }
-    #container { padding: 2em; }
-    #welcome, #status { margin-bottom: 2em; }
-    #welcome h1 span { display: block; font-size: 75%; }
-    #icon-status, #icon-book { float: left; height: 64px; margin-right: 1em; margin-top: -4px; width: 64px; }
-    #icon-book { display: none; }
-
-    @media (min-width: 768px) {
-        #wrapper { width: 80%; margin: 2em auto; }
-        #icon-book { display: inline-block; }
-        #status a, #next a { display: block; }
-
-        @-webkit-keyframes fade-in { 0% { opacity: 0; } 100% { opacity: 1; } }
-        @keyframes fade-in { 0% { opacity: 0; } 100% { opacity: 1; } }
-        .sf-toolbar { opacity: 0; -webkit-animation: fade-in 1s .2s forwards; animation: fade-in 1s .2s forwards;}
-    }
-</style>
+    <link rel="stylesheet" href="{{ asset('assets/components/welcome/welcome.css') }}">
 {% endblock %}

--- a/app/Resources/views/style_guide/index.html.twig
+++ b/app/Resources/views/style_guide/index.html.twig
@@ -1,0 +1,17 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Style Guide{% endblock %}
+
+{% block body %}
+<div id="wrapper">
+    <div id="container">
+        <h1>Components</h1>
+
+        {% include 'components/welcome/style_guide.html.twig' %}
+    </div>
+</div>
+{% endblock %}
+
+{% block stylesheets %}
+    <link rel="stylesheet" href="{{ asset('assets/components/welcome/welcome.css') }}">
+{% endblock %}

--- a/src/AppBundle/Controller/StyleGuideController.php
+++ b/src/AppBundle/Controller/StyleGuideController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace AppBundle\Controller;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+
+class StyleGuideController extends Controller
+{
+    /**
+     * @Route("/style-guide", name="homepage")
+     */
+    public function indexAction(Request $request)
+    {
+        return $this->render('style_guide/index.html.twig');
+    }
+}

--- a/src/AppBundle/Controller/StyleGuideController.php
+++ b/src/AppBundle/Controller/StyleGuideController.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpFoundation\Request;
 class StyleGuideController extends Controller
 {
     /**
-     * @Route("/style-guide", name="homepage")
+     * @Route("/style-guide", name="style_guide")
      */
     public function indexAction(Request $request)
     {

--- a/web/assets/base.css
+++ b/web/assets/base.css
@@ -1,0 +1,23 @@
+body { background: #F5F5F5; font: 18px/1.5 sans-serif; }
+h1, h2 { line-height: 1.2; margin: 0 0 .5em; }
+h1 { font-size: 36px; }
+h2 { font-size: 21px; margin-bottom: 1em; }
+p { margin: 0 0 1em 0; }
+a { color: #0000F0; }
+a:hover { text-decoration: none; }
+code { background: #F5F5F5; max-width: 100px; padding: 2px 6px; word-wrap: break-word; }
+#wrapper { background: #FFF; margin: 1em auto; max-width: 800px; width: 95%; }
+#container { padding: 2em; }
+#status { margin-bottom: 2em; }
+#icon-status, #icon-book { float: left; height: 64px; margin-right: 1em; margin-top: -4px; width: 64px; }
+#icon-book { display: none; }
+
+@media (min-width: 768px) {
+    #wrapper { width: 80%; margin: 2em auto; }
+    #icon-book { display: inline-block; }
+    #status a, #next a { display: block; }
+
+    @-webkit-keyframes fade-in { 0% { opacity: 0; } 100% { opacity: 1; } }
+    @keyframes fade-in { 0% { opacity: 0; } 100% { opacity: 1; } }
+    .sf-toolbar { opacity: 0; -webkit-animation: fade-in 1s .2s forwards; animation: fade-in 1s .2s forwards;}
+}

--- a/web/assets/components/welcome/welcome.css
+++ b/web/assets/components/welcome/welcome.css
@@ -1,0 +1,2 @@
+.welcome { margin-bottom: 2em; }
+.welcome--lead { display: block; font-size: 75%; }

--- a/web/assets/components/welcome/welcome.css
+++ b/web/assets/components/welcome/welcome.css
@@ -1,2 +1,2 @@
 .welcome { margin-bottom: 2em; }
-.welcome--lead { display: block; font-size: 75%; }
+.welcome__lead { display: block; font-size: 75%; }


### PR DESCRIPTION
Inspired by [the engineers at Lonely Planet](http://engineering.lonelyplanet.com/2014/05/18/a-maintainable-styleguide.html), I decided to try out component driven architecture using Twig macro's. Here's what I did:
- get rid of the inline style on the welcome page
- extract the HTML for a welcome component to a Twig macro
- extract the CSS for this welcome component to a separate file
- refactor the selectors to use [BEM naming](http://getbem.com/naming/)
- write a snippet for a style guide documenting this component
- create a placeholder for these snippets that is served by Symfony
